### PR TITLE
Display correct caseload and checkins when there is an active override

### DIFF
--- a/compass_vue/pages/caseload.vue
+++ b/compass_vue/pages/caseload.vue
@@ -66,6 +66,8 @@ export default {
       persons: [],
       adviserNetId: this.$route.params.id
         ? this.$route.params.id
+        : document.body.getAttribute("data-user-override")
+        ? document.body.getAttribute("data-user-override")
         : document.body.getAttribute("data-user-netid"),
     };
   },

--- a/compass_vue/pages/check-ins.vue
+++ b/compass_vue/pages/check-ins.vue
@@ -22,15 +22,7 @@
 </template>
 
 <script>
-import {
-  Card,
-  CardHeading,
-  TabsList,
-  TabsDisplay,
-  TabsItem,
-  TabsPanel,
-} from "axdd-components";
-import SearchStudent from "../components/search-student.vue";
+import { Card, CardHeading } from "axdd-components";
 import CheckInTableLoading from "../components/checkin-table-loading.vue";
 import CheckInTableDisplay from "../components/checkin-table-display.vue";
 
@@ -52,7 +44,9 @@ export default {
       isLoading: true,
       contacts: [],
       today: "",
-      userNetId: document.body.getAttribute("data-user-netid"),
+      userNetId: document.body.getAttribute("data-user-override")
+        ? document.body.getAttribute("data-user-override")
+        : document.body.getAttribute("data-user-netid"),
     };
   },
   computed: {},


### PR DESCRIPTION
Fix bug where the actual user's caseload and checkins were displayed even when there was an active user override