### PR TITLE
refactor AG validation and contact put/post

### DIFF
--- a/compass/serializers.py
+++ b/compass/serializers.py
@@ -228,7 +228,6 @@ class ContactWriteSerializer(serializers.ModelSerializer):
         return contact
 
     def update(self, instance, validated_data):
-        instance.app_user = validated_data.get("app_user", instance.app_user)
         instance.checkin_date = validated_data.get(
             "checkin_date", instance.checkin_date
         )

--- a/compass/tests/__init__.py
+++ b/compass/tests/__init__.py
@@ -26,11 +26,20 @@ class ApiTest(TestCase):
         session['samlUserdata'] = {'isMemberOf': [group]}
         session.save()
 
-    def post_response(self, url_name, body, **kwargs):
+    def post_response(self, url_name, body, netid=None, **kwargs):
+        if netid is not None:
+            self._set_user(netid)
         url = reverse(url_name, **kwargs)
         return self.client.post(url,
                                 data=body,
                                 content_type="application/json")
+
+    def put_response(self, url_name, netid, body, **kwargs):
+        self._set_user(netid)
+        url = reverse(url_name, kwargs=kwargs)
+        return self.client.put(url,
+                               data=body,
+                               content_type="application/json")
 
     def delete_response(self, url_name, netid, **kwargs):
         self._set_user(netid)

--- a/compass/tests/views/api/test_api.py
+++ b/compass/tests/views/api/test_api.py
@@ -1,0 +1,82 @@
+# Copyright 2023 UW-IT, University of Washington
+# SPDX-License-Identifier: Apache-2.0
+
+
+from datetime import datetime
+from django.test import Client
+from django.core.exceptions import PermissionDenied
+from django.test.client import RequestFactory
+from django.contrib.auth.models import User
+from unittest.mock import MagicMock, patch
+from compass.views.api.visit import VisitOMADView
+from compass.tests import ApiTest
+from compass.models import AccessGroup, VisitType
+from rest_framework.authtoken.models import Token
+from compass.views.api import BaseAPIView
+from compass.exceptions import OverrideNotPermitted
+
+
+class BaseAPIViewTest(ApiTest):
+    ag = None
+    request = None
+    view = None
+
+    def setUp(self):
+        self.ag = AccessGroup(name="Test Group",
+                              access_group_id="u_astra_group1")
+        self.ag.save()
+        self.request = RequestFactory().get('/api/')
+        self.view = BaseAPIView()
+
+    @patch('compass.models.is_group_member', return_value=True)
+    @patch.object(BaseAPIView, 'valid_user_override')
+    def test_access_group(self, mock_is_member, mock_is_override):
+        mock_is_override.return_value = True
+        ag = self.view.get_access_group(self.request, require_manager=False)
+        self.assertEqual(ag.name, "Test Group")
+
+        test_ag = AccessGroup(name="Another Group",
+                              access_group_id="u_astra_group2")
+
+        self.assertRaises(PermissionDenied, self.view.valid_access_group,
+                          self.request,
+                          [test_ag], require_manager=False)
+
+        try:
+            self.view.valid_access_group(self.request,
+                                         [self.ag],
+                                         require_manager=False)
+        except PermissionDenied:
+            self.fail("Access group is valid")
+
+    def _raise_override_not_permitted(self):
+        raise OverrideNotPermitted()
+
+    @patch('compass.models.is_group_member', return_value=True)
+    def test_valid_user_permission(self,
+                                   mock_is_member):
+
+        # Test Override
+        with patch.object(BaseAPIView,
+                          'valid_user_override',
+                          side_effect=self._raise_override_not_permitted):
+            self.assertRaises(PermissionDenied,
+                              self.view.valid_user_permission,
+                              self.request,
+                              allow_override=False)
+        with patch.object(BaseAPIView,
+                          'valid_user_override'):
+            try:
+                self.view.valid_user_permission(self.request,
+                                                allow_override=False)
+            except PermissionDenied:
+                self.fail("Override is valid")
+
+        # Test Access Groups
+        test_ags = [AccessGroup(name="Another Group",
+                                access_group_id="u_astra_group2")]
+        with self.assertRaises(PermissionDenied):
+            self.view.get_access_group(self.request, require_manager=False)
+            self.view.valid_user_permission(self.request,
+                                            access_groups=test_ags,
+                                            allow_override=False)

--- a/compass/urls.py
+++ b/compass/urls.py
@@ -115,7 +115,10 @@ urlpatterns += [
     re_path(r"^api/internal/contact/methods/$", ContactMethodsView.as_view()),
     re_path(r"^api/internal/contact/(?P<contactid>[\w]+)/$",
             ContactView.as_view(),
-            name="contact_view"),
+            name="contact_edit_view"),
+    re_path(r"^api/internal/contact/$",
+            ContactView.as_view(),
+            name="contact_create_view"),
     re_path(r"^api/internal/contact/$",  ContactView.as_view()),
     re_path(
         r"^api/internal/adviser/(?P<adviser_netid>[\w]+)/checkins/$",

--- a/compass_vue/components/add-contact.vue
+++ b/compass_vue/components/add-contact.vue
@@ -295,20 +295,37 @@ export default {
       var contactModal = Modal.getInstance(
         document.getElementById("contactModal" + this.contactId)
       );
-      this.saveStudentContact(this.person.student.system_key, this.contact)
-        .then(() => {
-          this.$emit("contactUpdated");
-          contactModal.hide();
-        })
-        .catch((error) => {
-          if (error.response.status == 401) {
-            this.updatePermissionDenied = true;
-            this.errorResponsePermission = error.response.data;
-            setTimeout(() => (this.updatePermissionDenied = false), 3000);
-          } else {
-            this.errorResponse = error.response.data;
-          }
-        });
+      if (this.contact.id !== undefined){
+        this.updateStudentContact(this.contact)
+          .then(() => {
+            this.$emit("contactUpdated");
+            contactModal.hide();
+          })
+          .catch((error) => {q
+            if (error.response.status == 401) {
+              this.updatePermissionDenied = true;
+              this.errorResponsePermission = error.response.data;
+              setTimeout(() => (this.updatePermissionDenied = false), 3000);
+            } else {
+              this.errorResponse = error.response.data;
+            }
+          });
+      } else {
+        this.saveStudentContact(this.person.student.system_key, this.contact)
+          .then(() => {
+            this.$emit("contactUpdated");
+            contactModal.hide();
+          })
+          .catch((error) => {
+            if (error.response.status == 401) {
+              this.updatePermissionDenied = true;
+              this.errorResponsePermission = error.response.data;
+              setTimeout(() => (this.updatePermissionDenied = false), 3000);
+            } else {
+              this.errorResponse = error.response.data;
+            }
+          });
+      }
     },
     validateContactForm() {
       let is_invalid = false;

--- a/compass_vue/mixins/data_mixin.js
+++ b/compass_vue/mixins/data_mixin.js
@@ -97,6 +97,12 @@ const dataMixin = {
         .post(postUrl, { contact: contact, system_key: systemkey })
         .catch(this._handleError);
     },
+   updateStudentContact: async function (contact) {
+      let putUrl = "/api/internal/contact/" + contact.id + "/";
+      return axios
+        .put(putUrl, { contact: contact})
+        .catch(this._handleError);
+    },
     saveStudentAffiliation: async function (systemkey, affiliation) {
       let postUrl = "/api/internal/student/" + systemkey + "/affiliations/";
       if (affiliation.studentAffiliationId !== null) {


### PR DESCRIPTION
- Refactors API user permission validation to a single call with optional parameters for manager, override, and assignment group checks `valid_user_permission`
- Splits Contact POST for create and update into separate PUT and POST endpoints
- Adds assignment group check to contact edit
- Prevents several contact fields from being changed on edit: student, access_group, app_user, created_date