### PR TITLE
fixes week calc

### DIFF
--- a/compass/dao/term.py
+++ b/compass/dao/term.py
@@ -4,10 +4,22 @@
 
 from uw_sws.term import get_term_by_date, get_term_after
 from compass.dao import current_datetime
+import datetime
 
 
 def current_term():
     return get_term_by_date(current_datetime().date())
+
+
+def week_of_term(term, current_date):
+    """
+    Returns the calendar week of the term for the given date.
+    """
+    start_date = term.first_day_quarter
+    start_of_first_week = start_date - datetime.timedelta(
+        days=start_date.isoweekday() % 7)
+    difference = (current_date - start_of_first_week).days
+    return difference // 7 + 1
 
 
 def term_context():
@@ -39,7 +51,7 @@ def term_context():
         'bterm_first_day': curr_term.bterm_first_date.isoformat() if (
             curr_term.bterm_first_date) else None,
         'last_final_exam_date': curr_term.last_final_exam_date.isoformat(),
-        'term_week': curr_term.get_week_of_term_for_date(current_dt),
+        'term_week': week_of_term(curr_term, current_dt.date()),
         'is_finals': is_finals,
         'is_break': is_break,
         'break_term_year': break_term.year,

--- a/compass/tests/dao/test_term.py
+++ b/compass/tests/dao/test_term.py
@@ -4,6 +4,8 @@
 
 from django.test import TestCase
 from uw_sws.util import fdao_sws_override
+from uw_sws.models import Term
+import datetime
 from compass.dao.term import *
 
 
@@ -32,7 +34,7 @@ class TermDAOFunctionsTest(TestCase):
                 'next_term_year': 2014,
                 'term_first_day': '2013-09-25',
                 'term_last_day': '2013-12-06',
-                'term_week': 3,
+                'term_week': 4,
             })
 
         with self.settings(CURRENT_DATETIME_OVERRIDE='2013-12-23 00:00:00'):
@@ -51,7 +53,7 @@ class TermDAOFunctionsTest(TestCase):
                 'next_term_year': 2014,
                 'term_first_day': '2013-09-25',
                 'term_last_day': '2013-12-06',
-                'term_week': 13,
+                'term_week': 14,
             })
 
         with self.settings(CURRENT_DATETIME_OVERRIDE='2013-06-30 00:00:00'):
@@ -70,5 +72,13 @@ class TermDAOFunctionsTest(TestCase):
                 'next_term_year': 2013,
                 'term_first_day': '2013-06-24',
                 'term_last_day': '2013-08-23',
-                'term_week': 1,
+                'term_week': 2,
             })
+
+    def test_week_of_term(self):
+        term = Term()
+        term.first_day_quarter = datetime.date(2024, 2, 7)
+        self.assertEqual(week_of_term(term, datetime.date(2024, 2, 7)), 1)
+        self.assertEqual(week_of_term(term, datetime.date(2024, 2, 10)), 1)
+        # Ensure week ticks over on Sunday, not relative to first day
+        self.assertEqual(week_of_term(term, datetime.date(2024, 2, 11)), 2)


### PR DESCRIPTION
Currently this uses the SWS  get_week_of_term_for_date function that calculates the number of weeks (as a unit of time) since the first day of the term.  If the term starts on a Wednesday, Week 1 runs from Wed>Tues.


This changes the calculation show the number of calendar weeks since the first day; bringing this in line with what MyUW does.  Now, if a term starts on Wednesday that Week 1 runs from Wed>Sat.

